### PR TITLE
Make version.pm compliant with the Lyon consensus

### DIFF
--- a/lib/version.pm
+++ b/lib/version.pm
@@ -48,6 +48,7 @@ $CLASS = 'version';
 	    *version::stringify = \&version::vxs::stringify;
 	    *{'version::(""'} = \&version::vxs::stringify;
 	    *{'version::(<=>'} = \&version::vxs::VCMP;
+	    *{'version::(cmp'} = \&version::vxs::VCMP;
 	    *version::parse = \&version::vxs::parse;
 	}
     }

--- a/t/10-lyon.t
+++ b/t/10-lyon.t
@@ -1,0 +1,41 @@
+#! perl
+
+use Test::More;
+
+use version;
+
+# These values are from the Lyon consensus, as taken from
+# https://gist.github.com/dagolden/9559280
+
+ok(version->new(1.0203) == version->new('1.0203'));
+ok(version->new(1.02_03) == version->new('1.02_03'));
+ok(version->new(v1.2.3) == version->new('v1.2.3'));
+ok(version->new(v1.2.3_0) == version->new('v1.2.3_0'));
+
+cmp_ok(version->new(1.0203), '==', version->new('1.0203'));
+cmp_ok(version->new(1.02_03), '==', version->new('1.02_03'));
+cmp_ok(version->new(v1.2.3), '==', version->new('v1.2.3'));
+cmp_ok(version->new(v1.2.3_0), '==', version->new('v1.2.3_0'));
+
+cmp_ok(version->new('1.0203')->numify, '==', '1.0203');
+is(version->new('1.0203')->normal, 'v1.20.300');
+
+cmp_ok(version->new('1.02_03')->numify, '==', '1.0203');
+is(version->new('1.02_03')->normal, 'v1.20.300');
+
+cmp_ok(version->new('v1.2.30')->numify, '==', '1.002030');
+is(version->new('v1.2.30')->normal, 'v1.2.30');
+cmp_ok(version->new('v1.2.3_0')->numify, '==', '1.002030');
+is(version->new('v1.2.3_0')->normal, 'v1.2.30');
+
+is(version->new("1.0203")->stringify, "1.0203");
+is(version->new("1.02_03")->stringify, "1.02_03");
+is(version->new("v1.2.30")->stringify, "v1.2.30");
+is(version->new("v1.2.3_0")->stringify, "v1.2.3_0");
+is(version->new(1.0203)->stringify, "1.0203");
+is(version->new(1.02_03)->stringify, "1.0203");
+is(version->new(v1.2.30)->stringify, "v1.2.30");
+local $TODO = 'Stringification of dotted decimal alpha versions is ambiguous';
+is(version->new(v1.2.3_0)->stringify, "v1.2.30");
+
+done_testing;

--- a/t/10-lyon.t
+++ b/t/10-lyon.t
@@ -35,7 +35,6 @@ is(version->new("v1.2.3_0")->stringify, "v1.2.3_0");
 is(version->new(1.0203)->stringify, "1.0203");
 is(version->new(1.02_03)->stringify, "1.0203");
 is(version->new(v1.2.30)->stringify, "v1.2.30");
-local $TODO = 'Stringification of dotted decimal alpha versions is ambiguous';
 is(version->new(v1.2.3_0)->stringify, "v1.2.30");
 
 done_testing;

--- a/t/coretests.pm
+++ b/t/coretests.pm
@@ -132,8 +132,8 @@ sub BaseTests {
     ok ( $version != $new_version, '$version != $new_version' );
 
     $version = $CLASS->$method("1.2.4");
-    ok ( $version > $new_version, '$version > $new_version' );
-    ok ( $new_version < $version, '$new_version < $version' );
+    ok ( $version < $new_version, '$version < $new_version' );
+    ok ( $new_version > $version, '$new_version > $version' );
     ok ( $version != $new_version, '$version != $new_version' );
 
     # now test with alpha version form with object
@@ -146,22 +146,22 @@ sub BaseTests {
     ok ( $new_version->is_alpha, '$new_version->is_alpha');
 
     $version = $CLASS->$method("1.2.4");
-    ok ( $version > $new_version, '$version > $new_version' );
-    ok ( $new_version < $version, '$new_version < $version' );
+    ok ( $version < $new_version, '$version < $new_version' );
+    ok ( $new_version > $version, '$new_version > $version' );
     ok ( $version != $new_version, '$version != $new_version' );
 
-    $version = $CLASS->$method("1.2.3.4");
+    $version = $CLASS->$method("1.2.34");
     $new_version = $CLASS->$method("1.2.3_4");
     ok ( $version == $new_version, '$version == $new_version' );
 
-    $version = $CLASS->$method("v1.2.3");
-    $new_version = $CLASS->$method("1.2.3.0");
+    $version = $CLASS->$method("v1.2.30");
+    $new_version = $CLASS->$method("1.2.30.0");
     ok ( $version == $new_version, '$version == $new_version' );
     $new_version = $CLASS->$method("1.2.3_0");
     ok ( $version == $new_version, '$version == $new_version' );
-    $new_version = $CLASS->$method("1.2.3.1");
+    $new_version = $CLASS->$method("1.2.30.1");
     ok ( $version < $new_version, '$version < $new_version' );
-    $new_version = $CLASS->$method("1.2.3_1");
+    $new_version = $CLASS->$method("1.2.30_1");
     ok ( $version < $new_version, '$version < $new_version' );
     $new_version = $CLASS->$method("1.1.999");
     ok ( $version > $new_version, '$version > $new_version' );

--- a/t/coretests.pm
+++ b/t/coretests.pm
@@ -152,9 +152,7 @@ sub BaseTests {
 
     $version = $CLASS->$method("1.2.3.4");
     $new_version = $CLASS->$method("1.2.3_4");
-    ok ( $version > $new_version, '$version > $new_version' );
-    ok ( $new_version < $version, '$new_version < $version' );
-    ok ( $version != $new_version, '$version != $new_version' );
+    ok ( $version == $new_version, '$version == $new_version' );
 
     $version = $CLASS->$method("v1.2.3");
     $new_version = $CLASS->$method("1.2.3.0");

--- a/vperl/vpp.pm
+++ b/vperl/vpp.pm
@@ -734,7 +734,7 @@ sub numify {
 	    my $denom = 10**(3-$width);
 	    my $quot = int($digit/$denom);
 	    my $rem = $digit - ($quot * $denom);
-	    $string .= sprintf("%0".$width."d_%d", $quot, $rem);
+	    $string .= sprintf("%0".$width."d%d", $quot, $rem);
 	}
 	else {
 	    $string .= sprintf("%03d", $digit);

--- a/vperl/vpp.pm
+++ b/vperl/vpp.pm
@@ -762,26 +762,14 @@ sub normal {
 	require Carp;
 	Carp::croak("Invalid version object");
     }
-    my $alpha = $self->{alpha} || "";
-    my $qv = $self->{qv} || "";
 
     my $len = $#{$self->{version}};
     my $digit = $self->{version}[0];
     my $string = sprintf("v%d", $digit );
 
-    for ( my $i = 1 ; $i < $len ; $i++ ) {
+    for ( my $i = 1 ; $i <= $len ; $i++ ) {
 	$digit = $self->{version}[$i];
 	$string .= sprintf(".%d", $digit);
-    }
-
-    if ( $len > 0 ) {
-	$digit = $self->{version}[$len];
-	if ( $alpha ) {
-	    $string .= sprintf("_%0d", $digit);
-	}
-	else {
-	    $string .= sprintf(".%0d", $digit);
-	}
     }
 
     if ( $len <= 2 ) {

--- a/vperl/vpp.pm
+++ b/vperl/vpp.pm
@@ -837,20 +837,6 @@ sub vcmp {
 	$i++;
     }
 
-    # tiebreaker for alpha with identical terms
-    if ( $retval == 0
-	&& $l == $r
-	&& $left->{version}[$m] == $right->{version}[$m]
-	&& ( $lalpha || $ralpha ) ) {
-
-	if ( $lalpha && !$ralpha ) {
-	    $retval = -1;
-	}
-	elsif ( $ralpha && !$lalpha) {
-	    $retval = +1;
-	}
-    }
-
     # possible match except for trailing 0's
     if ( $retval == 0 && $l != $r ) {
 	if ( $l < $r ) {

--- a/vperl/vpp.pm
+++ b/vperl/vpp.pm
@@ -503,7 +503,7 @@ sub scan_version {
 	$$rv->{width} = $width;
     }
 
-    while (isDIGIT($pos)) {
+    while (isDIGIT($pos) || $pos eq '_') {
 	$pos++;
     }
     if (!isALPHA($pos)) {
@@ -524,6 +524,7 @@ sub scan_version {
  		if ( !$qv && $s > $start && $saw_decimal == 1 ) {
 		    $mult *= 100;
  		    while ( $s < $end ) {
+			next if $s eq '_';
 			$orev = $rev;
  			$rev += $s * $mult;
  			$mult /= 10;
@@ -543,6 +544,7 @@ sub scan_version {
   		}
  		else {
  		    while (--$end >= $s) {
+			next if $end eq '_';
 			$orev = $rev;
  			$rev += $end * $mult;
  			$mult *= 10;
@@ -587,7 +589,7 @@ sub scan_version {
 		last;
 	    }
 	    if ( $qv ) {
-		while ( isDIGIT($pos) ) {
+		while ( isDIGIT($pos) || $pos eq '_') {
 		    $pos++;
 		}
 	    }

--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -935,21 +935,10 @@ Perl_vnormal(pTHX_ SV *vs)
 	digit = SvIV(tsv);
     }
     sv = Perl_newSVpvf(aTHX_ "v%"IVdf, (IV)digit);
-    for ( i = 1 ; i < len ; i++ ) {
+    for ( i = 1 ; i <= len ; i++ ) {
 	SV * tsv = *av_fetch(av, i, 0);
 	digit = SvIV(tsv);
 	Perl_sv_catpvf(aTHX_ sv, ".%"IVdf, (IV)digit);
-    }
-
-    if ( len > 0 )
-    {
-	/* handle last digit specially */
-	SV * tsv = *av_fetch(av, len, 0);
-	digit = SvIV(tsv);
-	if ( alpha )
-	    Perl_sv_catpvf(aTHX_ sv, "_%"IVdf, (IV)digit);
-	else
-	    Perl_sv_catpvf(aTHX_ sv, ".%"IVdf, (IV)digit);
     }
 
     if ( len <= 2 ) { /* short version, must be at least three */

--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -862,7 +862,7 @@ Perl_vnumify(pTHX_ SV *vs)
 	if ( width < 3 ) {
 	    const int denom = (width == 2 ? 10 : 100);
 	    const div_t term = div((int)PERL_ABS(digit),denom);
-	    Perl_sv_catpvf(aTHX_ sv, "%0*d_%d", width, term.quot, term.rem);
+	    Perl_sv_catpvf(aTHX_ sv, "%0*d%d", width, term.quot, term.rem);
 	}
 	else {
 	    Perl_sv_catpvf(aTHX_ sv, "%0*d", width, (int)digit);
@@ -873,8 +873,6 @@ Perl_vnumify(pTHX_ SV *vs)
     {
 	SV * tsv = *av_fetch(av, len, 0);
 	digit = SvIV(tsv);
-	if ( alpha && width == 3 ) /* alpha version */
-	    sv_catpvs(sv,"_");
 	Perl_sv_catpvf(aTHX_ sv, "%0*d", width, (int)digit);
     }
     else /* len == 0 */

--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -315,7 +315,7 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
     if ( !qv && width < 3 )
 	(void)hv_stores(MUTABLE_HV(hv), "width", newSViv(width));
 
-    while (isDIGIT(*pos))
+    while (isDIGIT(*pos) || *pos == '_')
 	pos++;
     if (!isALPHA(*pos)) {
 	I32 rev;
@@ -335,6 +335,8 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
 		if ( !qv && s > start && saw_decimal == 1 ) {
 		    mult *= 100;
  		    while ( s < end ) {
+			if (*s == '_')
+			    continue;
 			orev = rev;
  			rev += (*s - '0') * mult;
  			mult /= 10;
@@ -353,6 +355,8 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
   		}
  		else {
  		    while (--end >= s) {
+			if (*end == '_')
+			    continue;
 			int i  = (*end - '0');
                         if (   (mult == VERSION_MAX)
                             || (i > VERSION_MAX / mult)
@@ -400,7 +404,7 @@ Perl_scan_version(pTHX_ const char *s, SV *rv, bool qv)
 		break;
 	    }
 	    if ( qv ) {
-		while ( isDIGIT(*pos) )
+		while ( isDIGIT(*pos) || *pos == '_')
 		    pos++;
 	    }
 	    else {

--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -534,7 +534,16 @@ Perl_new_version(pTHX_ SV *ver)
 	if ( mg ) { /* already a v-string */
 	    const STRLEN len = mg->mg_len;
 	    const char * const version = (const char*)mg->mg_ptr;
+	    char *raw, *under;
+	    static const char underscore[] = "_";
 	    sv_setpvn(rv,version,len);
+	    raw = SvPV_nolen(rv);
+	    under = ninstr(raw, raw+len, underscore, underscore + 1);
+	    if (under) {
+		Move(under + 1, under, raw + len - under - 1, char);
+		SvCUR(rv)--;
+		*SvEND(rv) = '\0';
+	    }
 	    /* this is for consistency with the pure Perl class */
 	    if ( isDIGIT(*version) )
 		sv_insert(rv, 0, 0, "v", 1);

--- a/vutil/vutil.c
+++ b/vutil/vutil.c
@@ -1067,19 +1067,6 @@ Perl_vcmp(pTHX_ SV *lhv, SV *rhv)
 	i++;
     }
 
-    /* tiebreaker for alpha with identical terms */
-    if ( retval == 0 && l == r && left == right && ( lalpha || ralpha ) )
-    {
-	if ( lalpha && !ralpha )
-	{
-	    retval = -1;
-	}
-	else if ( ralpha && !lalpha)
-	{
-	    retval = +1;
-	}
-    }
-
     if ( l != r && retval == 0 ) /* possible match except for trailing 0's */
     {
 	if ( l < r )


### PR DESCRIPTION
This makes version.pm compliant with the [Lyon consensus](https://gist.github.com/dagolden/9559280). In particular it:
- makes version comparison not care about underscores
- ensures numify and normal never return underscores
- no longer considers an underscore a separator in dotted decimal versions, ignoring it instead.
- omits the underscore when stringifying vstring based versions

I have some reservations about that last commit, but apparently that was the consensus.

Possibly, the code could be cleaned up a little more after some of these changes, but that's a minor concern.

@dagolden, @rjbs, @haarg, @ether, @ribasushi
